### PR TITLE
Implement the package according to the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-Netstring
-=========
+# Netstring
 
 [![.github/workflows/test.yml](https://github.com/kyrylo/netstring/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/kyrylo/netstring/actions/workflows/test.yml)
 
-* [Netstring README][netstring-github]
-* [pkg.go.dev documentation][docs]
+- [Netstring README][netstring-github]
+- [pkg.go.dev documentation][docs]
 
-Introduction
-------------
+## Introduction
 
 _Netstring_ is a library for packing and parsing [netstrings][netstring],
 self-delimiting encoding of strings. The library is extremely simple and well-tested.
@@ -18,8 +16,7 @@ strings may be encoded as netstrings and then concatenated into a sequence of
 characters, which in turn may be transmitted over a reliable stream protocol
 such as TCP.
 
-Installation
-------------
+## Installation
 
 ### Go modules
 
@@ -34,10 +31,9 @@ Just `go get` the library:
 go get github.com/kyrylo/netstring
 ```
 
-Example
--------
+## Example
 
-### Parsing a byte string
+### Parsing a netstring into a byte string
 
 ```go
 package main
@@ -52,61 +48,65 @@ import (
 )
 
 func main() {
-	// input: "8:sunshine,"
-	s := []byte{
-		0x08, 0x00, 0x00, 0x00, 0x3a, 0x73, 0x75,
-		0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65, 0x2c,
+	// The netstring is "8:sunshine,"
+	netstr := []byte{
+		0x38, 0x3a, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65, 0x2c,
 	}
-	b := bufio.NewReader(bytes.NewReader([]byte(s)))
 
-	parsed, err := netstring.Parse(b)
+	// Create a reader.
+	buf := bufio.NewReader(bytes.NewReader(netstr))
+
+	// Parse the "8:sunshine," into "sunshine".
+	str, err := netstring.Parse(buf)
 	if err != nil {
 		log.Fatal(err)
-
 	}
 
-	// output: "sunshine"
-	fmt.Println(string(parsed))
+	// Output: "sunshine"
+	fmt.Printf("Input netstring: %s\n", netstr)
+	fmt.Printf("  Parsed string: %s\n", str)
 }
 ```
 
-### Packing bytes into a netstring
+### Packing a byte string into a netstring
 
 ```go
 package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/kyrylo/netstring"
 )
 
 func main() {
-	s := "sunshine"
-	packed := netstring.Pack([]byte(s))
+	s := []byte("sunshine")
+	netstr, err := netstring.Pack(s)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	// string: "8:sunshine,"
-	// bytes: [8 0 0 0 58 115 117 110 115 104 105 110 101 44]
-	fmt.Println(string(packed))
+	// netstr is "8:sunshine,"
+	// bytes: [0x38, 0x3a, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65, 0x2c]
+	fmt.Printf("    Input string: %s\n", s)
+	fmt.Printf("Output netstring: %s\n", netstr)
 }
 ```
 
-Supported Go versions
----------------------
+## Supported Go versions
 
-The library supports Go v1.11+. The CI file would be the best source of truth
+The library supports Go v1.17+. The CI file would be the best source of truth
 because it contains all Go versions that are tested against.
 
-Contact
--------
+## Contact
 
 In case you have a problem, question or a bug report, feel free to:
 
-* [file an issue][issues]
-* [tweet at me][twitter]
+- [file an issue][issues]
+- [tweet at me][twitter]
 
-License
--------
+## License
 
 The project uses the MIT License. See LICENSE.md for details.
 

--- a/netstring_test.go
+++ b/netstring_test.go
@@ -16,88 +16,153 @@ func TestParse(t *testing.T) {
 		bytes  []byte
 	}{
 		{
-			"Netstring length is less than 4 bytes",
-			[]byte{0x32, prefixCh, 0x61, 0x62, 0x63, 0x2c, suffixCh},
-			errors.New("got unexpected netstring prefix c, wanted :"),
+			"Netstring is empty",
+			[]byte{},
+			io.EOF,
 			[]byte{},
 		},
 		{
-			"Netstring length is more than 4 bytes",
-			[]byte{
-				0x32, 0x32, 0x32, 0x32, 0x01, prefixCh, 0x61,
-				0x62, 0x63, 0x2c, suffixCh,
-			},
-			errors.New("got unexpected netstring prefix \x01, wanted :"),
+			"Netstring length is 0",
+			[]byte{0x30, prefixCh, suffixCh},
+			nil,
 			[]byte{},
 		},
 		{
-			"Correct netstring (4-byte length, prefix : and suffix ,)",
-			[]byte{
-				0x05, 0x00, 0x00, 0x00, prefixCh, 0x68, 0x65,
-				0x6c, 0x6c, 0x6f, suffixCh,
-			},
-			nil,
-			[]byte{0x68, 0x65, 0x6c, 0x6c, 0x6f},
+			"Netstring length starts with a leading 0",
+			[]byte{0x30, 0x38, prefixCh, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65, suffixCh},
+			errors.New("leading zeros at the front of length are prohibited"),
+			[]byte{},
 		},
 		{
-			"Correct netstring (4-byte length, prefix : and suffix ,)",
-			[]byte{
-				0x05, 0x00, 0x00, 0x00, prefixCh, 0x68, 0x65,
-				0x6c, 0x6c, 0x6f, suffixCh,
-			},
-			nil,
-			[]byte{0x68, 0x65, 0x6c, 0x6c, 0x6f},
+			"Netstring is 0",
+			[]byte{0x30},
+			errors.New("leading zeros at the front of length are prohibited"),
+			[]byte{},
 		},
 		{
-			"Netstring without suffix ,",
+			"Netstring length consists of 1 digit",
 			[]byte{
-				0x05, 0x00, 0x00, 0x00, prefixCh, 0x68, 0x65,
-				0x6c, 0x6c, 0x6f,
+				0x38, prefixCh, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65, suffixCh,
+			},
+			nil,
+			[]byte("sunshine"),
+		},
+		{
+			"Netstring length consists of 2 digits",
+			[]byte{
+				0x31, 0x34, prefixCh, 0x70, 0x65, 0x72, 0x66, 0x65, 0x63, 0x74, 0x6c,
+				0x69, 0x62, 0x72, 0x61, 0x72, 0x79, suffixCh,
+			},
+			nil,
+			[]byte("perfectlibrary"),
+		},
+		{
+			"Netstring length consists of 3 digits",
+			[]byte{
+				0x31, 0x30, 0x35, prefixCh, 0x41, 0x20, 0x6e, 0x65, 0x74, 0x73, 0x74,
+				0x72, 0x69, 0x6e, 0x67, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x73, 0x65,
+				0x6c, 0x66, 0x2d, 0x64, 0x65, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x69, 0x6e,
+				0x67, 0x20, 0x65, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x20, 0x6f,
+				0x66, 0x20, 0x61, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x2e, 0x20,
+				0x4e, 0x65, 0x74, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x20, 0x61,
+				0x72, 0x65, 0x20, 0x76, 0x65, 0x72, 0x79, 0x20, 0x65, 0x61, 0x73, 0x79,
+				0x20, 0x74, 0x6f, 0x20, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
+				0x20, 0x61, 0x6e, 0x64, 0x20, 0x74, 0x6f, 0x20, 0x70, 0x61, 0x72, 0x73,
+				0x65, 0x2e, suffixCh,
+			},
+			nil,
+			[]byte(
+				"A netstring is a self-delimiting encoding of a string. Netstrings " +
+					"are very easy to generate and to parse.",
+			),
+		},
+		{
+			"Netstring consists of digigts",
+			[]byte{
+				0x32, prefixCh, 0x31, 0x34, suffixCh,
+			},
+			nil,
+			[]byte("14"),
+		},
+		{
+			"Netstring length is shorter than the actual string",
+			[]byte{
+				0x30, prefixCh, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65, suffixCh,
+			},
+			errors.New("unexpected suffix s, wanted ,"),
+			[]byte{},
+		},
+		{
+			"Netstring length is longer than the actual string",
+			[]byte{
+				0x31, 0x31, 0x31, prefixCh, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65,
+				0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65, prefixCh,
 			},
 			io.EOF,
 			[]byte{},
 		},
 		{
-			"Netstring longer than specified length",
+			"Netstring is missing prefix :",
 			[]byte{
-				0x05, 0x00, 0x00, 0x00, prefixCh, 0x68, 0x65,
-				0x6c, 0x6c, 0x6f, 0x6f, 0x6f, suffixCh,
+				0x38, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65, suffixCh,
 			},
-			errors.New("got unexpected netstring suffix o, wanted ,"),
+			errors.New("length number 67 is not in the range of 0-9"),
 			[]byte{},
 		},
 		{
-			"Netstring shorter than specified length",
+			"Netstring is missing suffix ,",
 			[]byte{
-				0x05, 0x00, 0x00, 0x00, prefixCh, 0x68, 0x65,
-				0x6c, 0x6c, suffixCh,
+				0x38, prefixCh, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65,
 			},
 			io.EOF,
+			[]byte{},
+		},
+		{
+			"Netstring ends with other suffix than ,",
+			[]byte{
+				0x38, prefixCh, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65, prefixCh,
+			},
+			errors.New("unexpected suffix :, wanted ,"),
+			[]byte{},
+		},
+		{
+			"Netstring includes non-digits in the length field",
+			[]byte{
+				0x6e, 0x65, prefixCh, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65,
+				prefixCh,
+			},
+			errors.New("length number 62 is not in the range of 0-9"),
+			[]byte{},
+		},
+		{
+			"Netstring includes both digits and non-digits in the length field",
+			[]byte{
+				0x38, 0x65, prefixCh, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65,
+				prefixCh,
+			},
+			errors.New("length number 53 is not in the range of 0-9"),
 			[]byte{},
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			r := bytes.NewReader(c.stream)
-			buf := bufio.NewReader(r)
-
-			b, err := Parse(buf)
+			netstr, err := Parse(bufio.NewReader(bytes.NewReader(c.stream)))
 			if c.err == nil && err != nil {
 				t.Fatalf("unexpected error: '%q'", err)
 				return
 			}
 			if c.err != nil && err != nil {
 				if c.err.Error() != err.Error() {
-					t.Fatalf("expected error %q, want %q", err, c.err)
+					t.Fatalf("expected error %q, got %q", c.err, err)
 				}
 				return
 			}
 			if c.err != nil && err == nil {
 				t.Errorf("expected error %q, got nothing", c.err)
 			}
-			if !bytes.Equal(b, c.bytes) {
-				t.Errorf("bytes: got %c, want %c", b, c.bytes)
+			if !bytes.Equal(netstr, c.bytes) {
+				t.Errorf("bytes: got %c, want %c", netstr, c.bytes)
 			}
 		})
 	}
@@ -106,31 +171,70 @@ func TestParse(t *testing.T) {
 func TestPack(t *testing.T) {
 	cases := []struct {
 		desc   string
-		input  []byte
+		input  string
+		err    error
 		result []byte
 	}{
 		{
-			`Packs string "sunshine" into a netstring`,
-			[]byte("sunshine"),
+			"Packs an empty string",
+			"",
+			nil,
+			[]byte{0x30, prefixCh, suffixCh},
+		},
+		{
+			"Packs a string with 1-digit length into a netstring",
+			"sunshine",
+			nil,
 			[]byte{
-				0x08, 0x00, 0x00, 0x00, prefixCh, 0x73, 0x75,
-				0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65, suffixCh,
+				0x38, prefixCh, 0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65,
+				suffixCh,
 			},
 		},
 		{
-			`Packs string "саншайн" into a netstring`,
-			[]byte("саншайн"),
+			"Packs a string with 2-digit length into a netstring",
+			"perfectlibrary",
+			nil,
 			[]byte{
-				0x0e, 0x00, 0x00, 0x00, prefixCh, 0xd1, 0x81,
-				0xd0, 0xb0, 0xd0, 0xbd, 0xd1, 0x88, 0xd0, 0xb0,
-				0xd0, 0xb9, 0xd0, 0xbd, suffixCh,
+				0x31, 0x34, prefixCh, 0x70, 0x65, 0x72, 0x66, 0x65, 0x63, 0x74, 0x6c,
+				0x69, 0x62, 0x72, 0x61, 0x72, 0x79, suffixCh,
+			},
+		},
+		{
+			"Packs a string with 3-digit length into a netstring",
+			"A netstring is a self-delimiting encoding of a string. Netstrings " +
+				"are very easy to generate and to parse.",
+			nil,
+			[]byte{
+				0x31, 0x30, 0x35, prefixCh, 0x41, 0x20, 0x6e, 0x65, 0x74, 0x73, 0x74,
+				0x72, 0x69, 0x6e, 0x67, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x73, 0x65,
+				0x6c, 0x66, 0x2d, 0x64, 0x65, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x69, 0x6e,
+				0x67, 0x20, 0x65, 0x6e, 0x63, 0x6f, 0x64, 0x69, 0x6e, 0x67, 0x20, 0x6f,
+				0x66, 0x20, 0x61, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x2e, 0x20,
+				0x4e, 0x65, 0x74, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x20, 0x61,
+				0x72, 0x65, 0x20, 0x76, 0x65, 0x72, 0x79, 0x20, 0x65, 0x61, 0x73, 0x79,
+				0x20, 0x74, 0x6f, 0x20, 0x67, 0x65, 0x6e, 0x65, 0x72, 0x61, 0x74, 0x65,
+				0x20, 0x61, 0x6e, 0x64, 0x20, 0x74, 0x6f, 0x20, 0x70, 0x61, 0x72, 0x73,
+				0x65, 0x2e, suffixCh,
 			},
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			b := Pack(c.input)
+			b, err := Pack([]byte(c.input))
+			if c.err == nil && err != nil {
+				t.Fatalf("unexpected error: '%q'", err)
+				return
+			}
+			if c.err != nil && err != nil {
+				if c.err.Error() != err.Error() {
+					t.Fatalf("expected error %q, got %q", c.err, err)
+				}
+				return
+			}
+			if c.err != nil && err == nil {
+				t.Errorf("expected error %q, got nothing", c.err)
+			}
 			if !bytes.Equal(b, c.result) {
 				t.Errorf("bytes: got %c, want %c", b, c.result)
 			}
@@ -139,36 +243,43 @@ func TestPack(t *testing.T) {
 }
 
 func TestParseAndPackInteropability(t *testing.T) {
-	b := []byte{
-		0x05, 0x00, 0x00, 0x00, prefixCh, 0x68, 0x65,
-		0x6c, 0x6c, 0x6f, suffixCh,
-	}
-	buf := bufio.NewReader(bytes.NewReader(b))
+	// 5:hello,
+	netstr := []byte{0x35, prefixCh, 0x68, 0x65, 0x6c, 0x6c, 0x6f, suffixCh}
 
-	str, err := Parse(buf)
+	str, err := Parse(bufio.NewReader(bytes.NewReader(netstr)))
 	if err != nil {
 		t.Fatalf("unexpected error: '%q'", err)
 		return
 	}
 
-	parsed := Pack(str)
-	if !bytes.Equal(b, parsed) {
-		t.Errorf("wanted %c to be the same as %c", b, parsed)
+	packed, err := Pack(str)
+
+	if err != nil {
+		t.Fatalf("unexpected error: '%q'", err)
+		return
+	}
+
+	if !bytes.Equal(netstr, packed) {
+		t.Errorf("wanted %c to be the same as %c", packed, netstr)
 	}
 }
 
 func TestPackAndParseInteropability(t *testing.T) {
-	// sunshine
-	b := []byte{0x73, 0x75, 0x6e, 0x73, 0x68, 0x69, 0x6e, 0x65}
+	str := []byte("sunshine")
 
-	packed := Pack(b)
-	str, err := Parse(bufio.NewReader(bytes.NewReader(packed)))
+	packed, err := Pack(str)
 	if err != nil {
 		t.Fatalf("unexpected error: '%q'", err)
 		return
 	}
 
-	if !bytes.Equal(b, str) {
-		t.Errorf("wanted %c to be the same as %c", b, str)
+	netstr, err := Parse(bufio.NewReader(bytes.NewReader(packed)))
+	if err != nil {
+		t.Fatalf("unexpected error: '%q'", err)
+		return
+	}
+
+	if !bytes.Equal(netstr, str) {
+		t.Errorf("wanted %c to be the same as %c", netstr, str)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/kyrylo/netstring/issues/4 (A netstring carries size information. It is encoded as 4-byte uint32. Why?)

We were calculating the netstring length wrong. Packing also used to work not according to the netstring spec. We used to assume that netstring length is encoded as a 4-byte uint32, while the spec clearly says that it is encoded as ASCII digits. Every bit in the length field means a digit, not a part of a length number.

Big thanks to the caring people who pointed that out. In this, almost complete, rewrite, we make sure that we calculate digits correctly.